### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
       steps:
         - uses: actions/checkout@v3.5.3
         - name: ${{ matrix.tools }}
-          uses: microsoft/action-python@0.7.0
+          uses: microsoft/action-python@0.7.1
           with:
             ${{ matrix.tools }}: true
             python_version: ${{ matrix.python_version }}
@@ -47,7 +47,7 @@ jobs:
 
 
   publish:
-    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.0
+    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.1
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD  }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish:
-    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.0
+    uses: microsoft/action-python/.github/workflows/publish.yml@0.7.1
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD  }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[microsoft/action-python](https://github.com/microsoft/action-python)** published a new release **[0.7.1](https://github.com/microsoft/action-python/releases/tag/0.7.1)** on 2023-07-04T19:10:40Z
