### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
               args: -m integration
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3.5.3
+        - uses: actions/checkout@v3.6.0
         - name: ${{ matrix.tools }}
           uses: microsoft/action-python@0.7.1
           with:

--- a/.github/workflows/schedule-update-actions.yml
+++ b/.github/workflows/schedule-update-actions.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v3.6.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.PAT }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.8.0
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.PAT }}

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -5,7 +5,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3 # important!
+      - uses: actions/checkout@v3.6.0 # important!
       - uses: euphoricsystems/action-sync-template-repository@v2.5.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.6.0](https://github.com/actions/checkout/releases/tag/v3.6.0)** on 2023-08-24T13:56:41Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
